### PR TITLE
Remove opacity property from URLs

### DIFF
--- a/themes/classic/notion-dark-classic.css
+++ b/themes/classic/notion-dark-classic.css
@@ -246,7 +246,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 

--- a/themes/classic/notion-darker-classic.css
+++ b/themes/classic/notion-darker-classic.css
@@ -247,7 +247,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 

--- a/themes/classic/notion-light-classic.css
+++ b/themes/classic/notion-light-classic.css
@@ -245,7 +245,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 

--- a/themes/enhanced/notion-dark-enhanced.css
+++ b/themes/enhanced/notion-dark-enhanced.css
@@ -116,7 +116,7 @@ code {
 }
 
 #write {
-    ååå max-width: 860px;
+    max-width: 860px;
     margin: 0 auto;
     padding: 30px;
     padding-bottom: 100px;
@@ -246,7 +246,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 

--- a/themes/enhanced/notion-darker-enhanced.css
+++ b/themes/enhanced/notion-darker-enhanced.css
@@ -247,7 +247,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 

--- a/themes/enhanced/notion-light-enhanced.css
+++ b/themes/enhanced/notion-light-enhanced.css
@@ -245,7 +245,6 @@ a,
     text-decoration: none;
     border-bottom: 0.05em solid;
     border-color: var(--url-underline-color);
-    opacity: 0.6;
     transition: all .1s ease-in;
 }
 


### PR DESCRIPTION
Following #19,  this PR removes access to the `.opacity` property from `.md-def-url`, which was breaking [reference-style links](https://www.markdownguide.org/basic-syntax/) after a PDF export.