### PR TITLE
fix <a> tag style, fix todo item style, fix code font too big on windows

### DIFF
--- a/themes/classic/notion-dark-classic.css
+++ b/themes/classic/notion-dark-classic.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -139,8 +139,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -240,7 +242,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -249,10 +250,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     background-color: var(--footnote-bg-color);
@@ -494,6 +491,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -503,7 +503,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -513,9 +512,6 @@ tt {
     font-weight: 600;
 }
 
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
-}
 
 /* TODO */
 .md-image>.md-meta {

--- a/themes/classic/notion-dark-classic.css
+++ b/themes/classic/notion-dark-classic.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -250,6 +250,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     background-color: var(--footnote-bg-color);

--- a/themes/classic/notion-darker-classic.css
+++ b/themes/classic/notion-darker-classic.css
@@ -69,7 +69,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -140,8 +140,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -241,7 +243,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -250,10 +251,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     color: var(--footnote-text-color);
@@ -495,6 +492,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -504,7 +504,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -512,10 +511,6 @@ tt {
     color: var(--todo-tick-color);
     font-size: 0.75em;
     font-weight: 600;
-}
-
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
 }
 
 /* TODO */

--- a/themes/classic/notion-darker-classic.css
+++ b/themes/classic/notion-darker-classic.css
@@ -69,7 +69,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -251,6 +251,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     color: var(--footnote-text-color);

--- a/themes/classic/notion-light-classic.css
+++ b/themes/classic/notion-light-classic.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -138,8 +138,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -239,7 +241,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -248,10 +249,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     background-color: var(--footnote-text-color);
@@ -493,6 +490,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -502,7 +502,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -510,10 +509,6 @@ tt {
     color: var(--todo-tick-color);
     font-size: 0.75em;
     font-weight: 600;
-}
-
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
 }
 
 /* TODO */

--- a/themes/classic/notion-light-classic.css
+++ b/themes/classic/notion-light-classic.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -249,6 +249,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     background-color: var(--footnote-text-color);

--- a/themes/enhanced/notion-dark-enhanced.css
+++ b/themes/enhanced/notion-dark-enhanced.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -139,8 +139,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -240,7 +242,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -249,10 +250,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     background-color: var(--footnote-bg-color);
@@ -494,6 +491,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -503,7 +503,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -513,9 +512,6 @@ tt {
     font-weight: 600;
 }
 
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
-}
 
 /* TODO */
 .md-image>.md-meta {

--- a/themes/enhanced/notion-dark-enhanced.css
+++ b/themes/enhanced/notion-dark-enhanced.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -250,6 +250,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     background-color: var(--footnote-bg-color);

--- a/themes/enhanced/notion-darker-enhanced.css
+++ b/themes/enhanced/notion-darker-enhanced.css
@@ -69,7 +69,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -140,8 +140,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -241,7 +243,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -250,10 +251,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     color: var(--footnote-text-color);
@@ -495,6 +492,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -504,7 +504,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -512,10 +511,6 @@ tt {
     color: var(--todo-tick-color);
     font-size: 0.75em;
     font-weight: 600;
-}
-
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
 }
 
 /* TODO */

--- a/themes/enhanced/notion-darker-enhanced.css
+++ b/themes/enhanced/notion-darker-enhanced.css
@@ -69,7 +69,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -251,6 +251,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     color: var(--footnote-text-color);

--- a/themes/enhanced/notion-light-enhanced.css
+++ b/themes/enhanced/notion-light-enhanced.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
+    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -138,8 +138,10 @@ code {
     margin-top: 30px;
 }
 
-a {
+#write a {
     color: var(--text-color);
+    text-decoration: none;
+    border-bottom: solid 1px var(--text-color);
 }
 
 h1,
@@ -239,7 +241,6 @@ hr {
     border: none
 }
 
-a,
 .md-def-url {
     color: var(--url-text-color);
     text-decoration: none;
@@ -248,10 +249,6 @@ a,
     transition: all .1s ease-in;
 }
 
-a:hover {
-    text-decoration: none;
-    opacity: 1;
-}
 
 sup.md-footnote {
     background-color: var(--footnote-text-color);
@@ -493,6 +490,9 @@ tt {
 #write .md-task-list-item>input[checked] {
     background: var(--todo-bg-color);
     border: 1px solid var(--todo-bg-color);
+}
+
+#write .md-task-list-item.task-list-done>p {
     text-decoration: line-through;
 }
 
@@ -502,7 +502,6 @@ tt {
     justify-content: center;
     content: '✓';
     position: absolute;
-    margin-top: 0.05rem;
     top: 0;
     left: 0;
     height: 100%;
@@ -510,10 +509,6 @@ tt {
     color: var(--todo-tick-color);
     font-size: 0.75em;
     font-weight: 600;
-}
-
-#write .md-task-list-item>input[checked]::after {
-    text-decoration: line-through;
 }
 
 /* TODO */

--- a/themes/enhanced/notion-light-enhanced.css
+++ b/themes/enhanced/notion-light-enhanced.css
@@ -67,7 +67,7 @@
     /* General */
     --font-size: 16px;
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    --monospace: 'SF Mono Medium', 'Consolas', 'Fira Code', 'Cousine', monospace;
+    --monospace: 'SF Mono Medium', 'Fira Code', 'Cousine', 'Consolas', monospace;
     --heading-char-color: var(--light-trait-400);
     --color-popover-bg-color: var(--text-color);
     --rawblock-edit-panel-bd: var(--bg-color-dark);
@@ -249,6 +249,10 @@ hr {
     transition: all .1s ease-in;
 }
 
+a:hover {
+    text-decoration: none;
+    opacity: 1;
+}
 
 sup.md-footnote {
     background-color: var(--footnote-text-color);


### PR DESCRIPTION
Fix some issues:

- Updated `a` tag underline style, using bottom border to avoid overlapping characters in non-English languages.
- Fixed The strike-through effect for to-do item.
- Fix a issue that drop-down menu items were underlined.

Style preview:
![image](https://github.com/adrian-fuertes/typora-notion-theme/assets/5465534/eb3e7ecf-6682-42d3-afa5-f5581e6e82b9)
Drop-down menu preview:
![image](https://github.com/adrian-fuertes/typora-notion-theme/assets/5465534/391f927a-a7fd-4522-994e-f6271c5bc598)
